### PR TITLE
Add GRAPHISOFT specific configuration options to the git-lfs-s3 script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pychache__
 *.tar.gz
 .DS_Store
+.idea

--- a/git_remote_s3/lfs.py
+++ b/git_remote_s3/lfs.py
@@ -175,7 +175,7 @@ def install(install_global = False):
     result = subprocess.run(
         ["git", "config", "--global" if install_global else "--add",
          "lfs.http://s3///.standalonetransferagent" if install_global else "lfs.standalonetransferagent",
-         "git-lfs-s3 # git-lfs filtering rules need our s3://... urls to be defined in the form: http(s)://s3///. So, consider this upon change." if install_global else "git-lfs-s3"],
+         "git-lfs-s3"],
         stderr=subprocess.PIPE,
     )
     if result.returncode != 0:

--- a/git_remote_s3/lfs.py
+++ b/git_remote_s3/lfs.py
@@ -218,7 +218,7 @@ def inferS3Url(event: dict) -> str:
     parsed_url = urlparse(remote_url)
     path = parsed_url.path
     repo_name = os.path.basename(path)  # extract last component from url path and use it as repo
-    bucket_name = os.path.splitext(repo_name)[0]  # remove optional .git extension and use it as bucket
+    bucket_name = os.path.splitext(repo_name)[0].lower()  # remove optional .git extension and use it as bucket
     return f"s3://{bucket_name}/{repo_name}"
 
 

--- a/git_remote_s3/lfs.py
+++ b/git_remote_s3/lfs.py
@@ -217,8 +217,13 @@ def inferS3Url(event: dict) -> str:
         sys.exit(1)
     remote_url = result.stdout.decode("utf-8").strip()
     parsed_url = urlparse(remote_url)
-    path = parsed_url.path
-    repo_name = os.path.basename(path)  # extract last component from url path and use it as repo
+    path = parsed_url.path or ""
+    if path.endswith("/"):
+        path = path.rstrip("/")  # remove any trailing slashes so basename works
+    repo_name = os.path.basename(path) # extract last component from url path and use it as repo name
+    if not repo_name:
+        write_error_event_with_code(32, f"cannot infer repository name from remote url '{remote_url}'")
+        sys.exit(1)
     bucket_name = os.path.splitext(repo_name)[0].lower()  # remove optional .git extension and use it as bucket
     return f"s3://{bucket_name}/{repo_name}"
 

--- a/git_remote_s3/lfs.py
+++ b/git_remote_s3/lfs.py
@@ -169,12 +169,12 @@ def install(install_global = False):
     # Here, we had to use a slightly awkward syntax because git-lfs only accepts
     # http(s) urls to filter configuration values for custom transfer agent urls.
     # As we have to use an s3:// url to access our AWS server,
-    # this can be only defined in git-lfs filters in the form http://s3///
+    # this can be only defined in git-lfs filters in the form https://s3///
     # ensuring the proper config value to be found among global configs.
     #
     result = subprocess.run(
         ["git", "config", "--global" if install_global else "--add",
-         "lfs.http://s3///.standalonetransferagent" if install_global else "lfs.standalonetransferagent",
+         "lfs.https://s3///.standalonetransferagent" if install_global else "lfs.standalonetransferagent",
          "git-lfs-s3"],
         stderr=subprocess.PIPE,
     )

--- a/git_remote_s3/lfs.py
+++ b/git_remote_s3/lfs.py
@@ -104,7 +104,7 @@ class LFSProcess:
             self.init_s3_bucket()
             if list(
                 self.s3_bucket.objects.filter(
-                    Prefix=f"{self.prefix}/lfs/{event['oid']}"
+                    Prefix=f"{self.prefix}/{event['oid']}"
                 )
             ):
                 logger.debug("object already exists")
@@ -115,7 +115,7 @@ class LFSProcess:
                 return
             self.s3_bucket.upload_file(
                 event["path"],
-                f"{self.prefix}/lfs/{event['oid']}",
+                f"{self.prefix}/{event['oid']}",
                 Callback=ProgressPercentage(event["oid"]),
             )
             sys.stdout.write(
@@ -132,7 +132,7 @@ class LFSProcess:
             self.init_s3_bucket()
             temp_dir = os.path.abspath(".git/lfs/tmp")
             self.s3_bucket.download_file(
-                Key=f"{self.prefix}/lfs/{event['oid']}",
+                Key=f"{self.prefix}/{event['oid']}",
                 Filename=f"{temp_dir}/{event['oid']}",
                 Callback=ProgressPercentage(event["oid"]),
             )

--- a/git_remote_s3/lfs.py
+++ b/git_remote_s3/lfs.py
@@ -131,6 +131,7 @@ class LFSProcess:
         try:
             self.init_s3_bucket()
             temp_dir = os.path.abspath(".git/lfs/tmp")
+            os.makedirs(temp_dir, exist_ok=True)
             self.s3_bucket.download_file(
                 Key=f"{self.prefix}/{event['oid']}",
                 Filename=f"{temp_dir}/{event['oid']}",

--- a/git_remote_s3/lfs.py
+++ b/git_remote_s3/lfs.py
@@ -156,9 +156,9 @@ class LFSProcess:
         sys.stdout.flush()
 
 
-def install():
+def install(install_global = False):
     result = subprocess.run(
-        ["git", "config", "--add", "lfs.customtransfer.git-lfs-s3.path", "git-lfs-s3"],
+        ["git", "config", "--global" if install_global else "--add", "lfs.customtransfer.git-lfs-s3.path", "git-lfs-s3"],
         stderr=subprocess.PIPE,
     )
     if result.returncode != 0:
@@ -166,7 +166,7 @@ def install():
         sys.stderr.flush()
         sys.exit(1)
     result = subprocess.run(
-        ["git", "config", "--add", "lfs.standalonetransferagent", "git-lfs-s3"],
+        ["git", "config", "--global" if install_global else "--add", "lfs.http://s3///.standalonetransferagent" if install_global else "lfs.standalonetransferagent", "git-lfs-s3"],
         stderr=subprocess.PIPE,
     )
     if result.returncode != 0:
@@ -182,6 +182,9 @@ def main():  # noqa: C901
     if len(sys.argv) > 1:
         if "install" == sys.argv[1]:
             install()
+            sys.exit(0)
+        elif "glinstall" == sys.argv[1]:
+            install(install_global=True)
             sys.exit(0)
         elif "debug" == sys.argv[1]:
             logger.setLevel(logging.DEBUG)

--- a/git_remote_s3/lfs.py
+++ b/git_remote_s3/lfs.py
@@ -86,11 +86,11 @@ class LFSProcess:
             stderr=subprocess.PIPE,
         )
         if result.returncode != 0:
-            logger.error(result.stderr.decode("utf-8").strip())
+            logger.error(f"lfs.awsendpoint isn't specified and cannot read from git config! result: {result.stderr.decode('utf-8').strip()}")
             error_event = {
                 "error": {
-                    "code": 2,
-                    "message": "cannot read lfs.awsendpoint from git config",
+                    "code": 33,
+                    "message": "lfs.awsendpoint isn't specified and cannot read from git config",
                 }
             }
             sys.stdout.write(f"{json.dumps(error_event)}")
@@ -219,11 +219,11 @@ def inferS3Url(event: dict) -> str:
         stderr=subprocess.PIPE,
     )
     if result.returncode != 0:
-        logger.error(result.stderr.decode("utf-8").strip())
+        logger.error(f"lfs.url isn't specified and cannot resolve remote '{event['remote']}'! result: {result.stderr.decode('utf-8').strip()}")
         error_event = {
             "error": {
-                "code": 2,
-                "message": f"lfs.url isn't specified and cannot resolve remote \"{event['remote']}\"",
+                "code": 34,
+                "message": f"lfs.url isn't specified and cannot resolve remote '{event['remote']}'",
             }
         }
         sys.stdout.write(f"{json.dumps(error_event)}")
@@ -280,7 +280,13 @@ def main():  # noqa: C901
             # already have validated the origin name
             if not validate_ref_name(event["remote"]):
                 logger.error(f"invalid ref {event['remote']}")
-                sys.stdout.write("{}\n")
+                error_event = {
+                    "error": {
+                        "code": 35,
+                        "message": f"invalid ref {event['remote']}",
+                    }
+                }
+                sys.stdout.write(f"{json.dumps(error_event)}")
                 sys.stdout.flush()
                 sys.exit(1)
 


### PR DESCRIPTION
In this pull request i have implemented the following things:
- Read the AWS server url from `lfs.endpoint` git config value instead of `AWS_ENDPOINT` environment variable
- In case if no `lfs.url` has been specified in git config, we conclude the bucket and repo name using origin's url as default
- `glinstall` command has been implemented to provide the install of lfs-s3 custom transfer agent globally instead of need to install locally in each repo